### PR TITLE
Add colorful frontend demo

### DIFF
--- a/PRD_summary.md
+++ b/PRD_summary.md
@@ -1,0 +1,18 @@
+# Handball Connect PRD Summary
+
+This document summarizes the main sections and goals from the provided "Handball Connect" product requirements document. The PRD proposes a digital platform to streamline talent promotion within professional handball.
+
+## Key Points
+- **Current Problems**: Handball agents rely on ad-hoc tools like email and Dropbox to share player information. These methods lack organization, metadata, analytics, and professional presentation. Clubs struggle to evaluate players efficiently, and players can miss opportunities.
+- **Vision**: Build a dedicated, modern platform for agents and clubs, focusing on user-friendly player profiles, video hosting, search tools, communication, and compliance with data regulations.
+- **MVP Features**:
+  - Player profile management with CV uploads.
+  - Video hosting and basic editing with view analytics.
+  - Secure sharing of profiles and reels.
+  - Basic player search for clubs.
+  - In-platform messaging.
+  - Standardized performance data fields and dashboards.
+  - GDPR-compliant data handling.
+- **Business Model**: Tiered SaaS subscriptions with a freemium entry for agents and paid tiers for professional agents, agencies, and clubs. Potential additional revenue from premium features or partnerships.
+- **Roadmap Considerations**: Future AI-assisted video tagging, deeper analytics, mobile apps, and partnerships with governing bodies (e.g., EHAA, EHF).
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# taste-check
+# Handball Connect Prototype
+
+This repository contains a small demo of a potential user interface for the Handball Connect platform.
+
+## Viewing the Demo
+
+Open `frontend/index.html` in a modern web browser to explore the sample UI. The page demonstrates a minimal search experience with a light/dark mode toggle.
+
+The styling is intentionally vibrant and includes basic animations for a smoother user experience. It is not a production-ready design but illustrates how the app could look.
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Handball Connect Demo</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Handball Connect</h1>
+        <button id="modeToggle" aria-label="Toggle dark mode">🌙</button>
+    </header>
+    <main>
+        <section class="hero">
+            <h2>Discover Talent Effortlessly</h2>
+            <p>Search, evaluate and connect with handball players in style.</p>
+        </section>
+        <section class="search-section">
+            <input type="text" id="searchInput" placeholder="Search players..."/>
+            <div id="playerList" class="player-list"></div>
+        </section>
+    </main>
+    <footer>
+        <p>Prototype demo – for illustration purposes only.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,36 @@
+const searchInput = document.getElementById('searchInput');
+const playerList = document.getElementById('playerList');
+const modeToggle = document.getElementById('modeToggle');
+
+const players = [
+  { name: 'Alex Goalkeeper', position: 'GK', country: 'Germany' },
+  { name: 'Briana Wing', position: 'LW', country: 'France' },
+  { name: 'Carlos Pivot', position: 'P', country: 'Spain' },
+  { name: 'Dana Back', position: 'RB', country: 'Norway' }
+];
+
+function renderPlayers(filter = '') {
+  playerList.innerHTML = '';
+  players
+    .filter(p => p.name.toLowerCase().includes(filter.toLowerCase()))
+    .forEach(player => {
+      const card = document.createElement('div');
+      card.className = 'player-card';
+      card.innerHTML = `
+        <h3>${player.name}</h3>
+        <p><strong>Position:</strong> ${player.position}</p>
+        <p><strong>Country:</strong> ${player.country}</p>
+      `;
+      playerList.appendChild(card);
+    });
+}
+
+searchInput.addEventListener('input', e => {
+  renderPlayers(e.target.value);
+});
+
+modeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('dark');
+});
+
+renderPlayers();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,77 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+
+:root {
+  --primary-bg: linear-gradient(135deg, #0b72b9, #2fbf71);
+  --text-color: #333;
+  --bg-color: #ffffff;
+  --accent-color: #ffdc64;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+  transition: background 0.3s, color 0.3s;
+}
+
+body.dark {
+  --bg-color: #1a1a1a;
+  --text-color: #f0f0f0;
+}
+
+header {
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--primary-bg);
+  color: white;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.hero {
+  padding: 4rem 2rem;
+  text-align: center;
+  background: var(--primary-bg);
+  color: white;
+}
+
+.search-section {
+  padding: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.search-section input {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  margin-bottom: 1rem;
+}
+
+.player-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.player-card {
+  background: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s;
+}
+
+.player-card:hover {
+  transform: translateY(-5px);
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #fafafa;
+}


### PR DESCRIPTION
## Summary
- create `frontend` folder with a styled HTML demo
- implement a light/dark mode toggle and sample player search
- update README with instructions for viewing the demo

## Testing
- `pytest -q` *(fails: command not found)*